### PR TITLE
fix: error build path does not exist

### DIFF
--- a/stubs/docker-compose.yml
+++ b/stubs/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
     laravel.test:
         build:
-            context: ./docker/7.2
+            context: ./vendor/ajuchacko/sail-7.x/runtimes/7.2
             dockerfile: Dockerfile
             args:
                 WWWGROUP: '${WWWGROUP}'


### PR DESCRIPTION
This PR will fix an error:
build path '[project-home]/docker/7.2 either does not exist, is not accessible, or is not a valid URL.